### PR TITLE
Enable output caching and update solution structure

### DIFF
--- a/LocalBlog.sln
+++ b/LocalBlog.sln
@@ -3,10 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.12.35527.113
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthZeroPoc", "AuthZeroPoc\AuthZeroPoc.csproj", "{62398150-6DEC-4466-80B3-6F0BD8680D3C}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FrontEnd", "FrontEnd\FrontEnd.csproj", "{0767F971-3835-4689-9E51-746036B6ED39}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{52716B4E-2F11-43F0-A170-09598F9D771C}"
 	ProjectSection(SolutionItems) = preProject
 		Readme.md = Readme.md
@@ -22,14 +18,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{62398150-6DEC-4466-80B3-6F0BD8680D3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{62398150-6DEC-4466-80B3-6F0BD8680D3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{62398150-6DEC-4466-80B3-6F0BD8680D3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{62398150-6DEC-4466-80B3-6F0BD8680D3C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0767F971-3835-4689-9E51-746036B6ED39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0767F971-3835-4689-9E51-746036B6ED39}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0767F971-3835-4689-9E51-746036B6ED39}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0767F971-3835-4689-9E51-746036B6ED39}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9AB53C92-D789-4A42-BDF1-571DC1B0C967}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9AB53C92-D789-4A42-BDF1-571DC1B0C967}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9AB53C92-D789-4A42-BDF1-571DC1B0C967}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/ModernBlog/Components/Pages/DisplayBlog.razor.cs
+++ b/ModernBlog/Components/Pages/DisplayBlog.razor.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.OutputCaching;
 using Models;
 using ModernBlog.Services;
 
 namespace ModernBlog.Components.Pages;
 
+[OutputCache]
 public partial class DisplayBlog
 {
     [Parameter]

--- a/ModernBlog/Components/Pages/Home.razor.cs
+++ b/ModernBlog/Components/Pages/Home.razor.cs
@@ -1,10 +1,12 @@
 ﻿using Blazorise.DataGrid;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.OutputCaching;
 using Models;
 using ModernBlog.Services;
 
 namespace ModernBlog.Components.Pages;
 
+[OutputCache]
 public partial class Home
 {
     protected List<BlogCategory> blogPosts = [];

--- a/ModernBlog/Program.cs
+++ b/ModernBlog/Program.cs
@@ -21,6 +21,14 @@ RegisterAuth0(builder);
 RegisterConnectionToDb(builder);
 
 RegisterServices(builder);
+builder.Services.AddOutputCache(cfg =>
+{
+    cfg.AddBasePolicy(bldr =>
+    {
+        bldr.With(r => r.HttpContext.Request.Path.StartsWithSegments("/"));
+        bldr.Expire(TimeSpan.FromMinutes(1));
+    });
+});
 
 builder.Services
     .AddBlazorise(options =>
@@ -49,6 +57,7 @@ app.UseHttpsRedirection();
 app.UseAntiforgery();
 
 RegisterAuth0Routes(app);
+app.UseOutputCache();
 
 app.MapStaticAssets();
 app.MapRazorComponents<App>()

--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,13 @@
-Blog Engine in Blazor
+# Blog Engine in Blazor
+This application has been developed utilizing the Blazor framework with a PostgreSQL database backend.
+
+For the purpose of this demonstration, the application's functionality has been intentionally streamlined. Key features include a dedicated screen for category creation and a separate screen for managing blog entries.
+
+The homepage presents a comprehensive list of all available blogs. A double-click action on any listed blog entry initiates its launch.
+
+While designed to operate on a local Raspberry Pi environment, the application incorporates Auth0 for user authentication and authorization.
+
+- **Authorized Users:** Possess the privilege to create new categories and manage blog entries.
+- **Other Users:** Retain the ability to view all published blogs but are restricted from making any content modifications.
+
+To execute the application, please ensure the environment variable 'ConnectionStrings_BlogDbConnection' is correctly configured to point to your specific PostgreSQL database instance. With this prerequisite met, the application should be ready for immediate use.


### PR DESCRIPTION
Removed AuthZeroPoc and FrontEnd projects from LocalBlog.sln. Updated project configuration platforms accordingly. Added OutputCache attribute to DisplayBlog and Home classes. Registered output caching services in Program.cs with a base policy and middleware. Updated Readme.md with detailed application description and instructions.