### PR TITLE
Fixes save blog error.

### DIFF
--- a/ModernBlog/Program.cs
+++ b/ModernBlog/Program.cs
@@ -128,7 +128,7 @@ static void ConfigureLogging(WebApplicationBuilder builder)
     var config = builder.Configuration;
     StringBuilder filePath = new();
     filePath.Append(Path.GetTempPath() + "/");
-    filePath.Append("BlazorChat-.log");
+    filePath.Append("ModernBlog-.log");
     Log.Logger = new LoggerConfiguration()
         .ReadFrom.Configuration(config)
         .Enrich.FromLogContext()

--- a/ModernBlog/Services/BlogPostService.cs
+++ b/ModernBlog/Services/BlogPostService.cs
@@ -29,6 +29,8 @@ public class BlogPostService(BlogContext context, ILogger<BlogPostService> logge
     {
         var authState = await stateProvider.GetAuthenticationStateAsync();
         var user = authState.User;
+        post.Title = post.Title.Truncate(120);
+        post.Introduction = post.Introduction.Truncate(255);
         if (user.Identity?.IsAuthenticated == true)
         {
             post.UserId = user.Identity.Name;


### PR DESCRIPTION
If the title or introduction is longer than defined value the application failed to save the blog. Fixed by limiting the size of the strings.